### PR TITLE
Do not grant localstack access to host's docker.sock

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -19,12 +19,10 @@ services:
     restart: unless-stopped
     environment:
       - SERVICES=sns,sqs
-      - DOCKER_HOST=unix:///var/run/docker.sock
       - HOSTNAME_EXTERNAL=localstack
       - LS_LOG=warn
     volumes:
       - ./docker/localstack_bootstrap.sh:/etc/localstack/init/ready.d/localstack_bootstrap.sh
-      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - standardnotes_self_hosted
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -20,12 +20,10 @@ services:
     restart: unless-stopped
     environment:
       - SERVICES=sns,sqs
-      - DOCKER_HOST=unix:///var/run/docker.sock
       - HOSTNAME_EXTERNAL=localstack
       - LS_LOG=warn
     volumes:
       - ./localstack_bootstrap.sh:/etc/localstack/init/ready.d/localstack_bootstrap.sh
-      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - standardnotes_self_hosted
 


### PR DESCRIPTION
I think localstack doesn't need to access the host system's Docker socket. For security reasons, I suggest to remove the corresponding volume.