### PR TITLE
Adding support for redis databases with passwords

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -58,7 +58,9 @@ if [ -z "$REDIS_HOST" ]; then
   export REDIS_HOST="cache"
 fi
 
-export REDIS_URL="redis://$REDIS_HOST"
+if [ -z "$REDIS_URL" ]; then
+  export REDIS_URL="redis://$REDIS_HOST"
+fi
 
 ##########
 # SHARED #


### PR DESCRIPTION
Redis databases with passwords can be supported by specifying the environment parameter REDIS_URL=redis://:$REDIS_PASSWORD@redis:6379 Without this change the redis URL will always be hardcoded without support for a password