### PR TITLE
Add missing version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@standardnotes/server-monorepo",
   "private": true,
   "author": "Standard Notes",
+  "version": "0.0.1",
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
This is needed so that yarn install works for the repo.

Example of the error:
```
❯ yarn add https://github.com/standardnotes/server/tarball/@standardnotes/api-gateway@1.45.0
yarn add v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
warning napa > tar-pack > tar@2.2.2: This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.
error Can't add "@standardnotes/server-monorepo": invalid package version "".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

All approaches fail
```
yarn add https://github.com/standardnotes/server/tarball/@standardnotes/api-gateway@1.45.0
```

```
❯ yarn add sn-server@https://github.com/standardnotes/server
yarn add v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
warning napa > tar-pack > tar@2.2.2: This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.
error Can't add "sn-server": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

Whereas the standardnotes/app repo does have `"version": "0.0.1",` which allows it to be installed.
https://github.com/standardnotes/app/blob/main/package.json#L3


Reference yarn specific issues specifying why not having one will break things:
https://github.com/yarnpkg/yarn/issues/5097
https://github.com/yarnpkg/yarn/issues/5292