### PR TITLE
feat: enable Write-Ahead Logging mode for SQLite

### DIFF
--- a/packages/auth/src/Bootstrap/DataSource.ts
+++ b/packages/auth/src/Bootstrap/DataSource.ts
@@ -114,6 +114,8 @@ export class AppDataSource {
         ...commonDataSourceOptions,
         type: 'sqlite',
         database: this.env.get('DB_SQLITE_DATABASE_PATH'),
+        enableWAL: true,
+        busyErrorRetry: 2000,
       }
 
       this._dataSource = new DataSource(sqliteDataSourceOptions)

--- a/packages/revisions/src/Bootstrap/DataSource.ts
+++ b/packages/revisions/src/Bootstrap/DataSource.ts
@@ -80,6 +80,8 @@ export class AppDataSource {
         ...commonDataSourceOptions,
         type: 'sqlite',
         database: this.env.get('DB_SQLITE_DATABASE_PATH'),
+        enableWAL: true,
+        busyErrorRetry: 2000,
       }
 
       this.dataSource = new DataSource(sqliteDataSourceOptions)

--- a/packages/syncing-server/src/Bootstrap/DataSource.ts
+++ b/packages/syncing-server/src/Bootstrap/DataSource.ts
@@ -98,6 +98,8 @@ export class AppDataSource {
         ...commonDataSourceOptions,
         type: 'sqlite',
         database: this.env.get('DB_SQLITE_DATABASE_PATH'),
+        enableWAL: true,
+        busyErrorRetry: 2000,
       }
 
       this._dataSource = new DataSource(sqliteDataSourceOptions)


### PR DESCRIPTION
This addresses the concurrency issue we had during the E2E test suite run where we would have many `SQLITE_BUSY` errors occur.

More context: https://www.sqlite.org/wal.html

TypeORM support: https://github.com/typeorm/typeorm/pull/8616