### PR TITLE
fix(api-gateway): add possibility to configure keep-alive timeout

### DIFF
--- a/packages/api-gateway/bin/server.ts
+++ b/packages/api-gateway/bin/server.ts
@@ -102,9 +102,11 @@ void container.load().then((container) => {
     })
   })
 
-  const serverInstance = server.build()
+  const serverInstance = server.build().listen(env.get('PORT'))
 
-  serverInstance.listen(env.get('PORT'))
+  const keepAliveTimeout = env.get('KEEP_ALIVE_TIMEOUT', true) ? +env.get('KEEP_ALIVE_TIMEOUT', true) : 5000
+
+  serverInstance.keepAliveTimeout = keepAliveTimeout
 
   logger.info(`Server started on port ${process.env.PORT}`)
 })


### PR DESCRIPTION
This is to address the connection reset issue with AWS ALB: https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83

More context: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout