### PR TITLE
Adds support for loading environment vars from file.

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Load environment variables from file if available
+if [ ! -z "$ENVIRONMENT_FILE" ]; then
+  if [ ! -f "$ENVIRONMENT_FILE" ]; then
+    echo "No environment file found at '$ENVIRONMENT_FILE'."
+    exit 1
+  fi
+  export $(cat "$ENVIRONMENT_FILE" | xargs)
+fi
+
 # Setup environment variables
 
 export MODE="self-hosted"


### PR DESCRIPTION
The docker entrypoint script appears to look for secrets (along with other things) in the environment.  Providing secrets via environment variables has a couple of negative security implications:
1. Anyone who can see your docker compose/swarm file can see your secrets.
2. Anyone who can inspect your docker environment can see your secrets (e.g., `docker ps`)

Docker swarm supports the concept of Docker Secrets, which are defined and managed by docker swarm with their own set of access controls independent from access to to management and compose files.  When one uses docker secrets, they get mounted in a `tmpfs` drive inside the container at `/run/secrets/*` (where `*` is the name of the secret defined in the compose/swarm file).  These secrets can be simple one-line files (e.g., a password) or complex files (e.g., a TLS key).

By having the entrypoint script load environment variables from a provided file path like this, we can securely move the secrets into the container and load them without ever exposing them outside of the container.