### PR TITLE
fix: MySQL(8.4.0) native password authentication changes.

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -54,7 +54,7 @@ services:
     ports:
       - 3306
     restart: unless-stopped
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    command: --mysql-native-password=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     volumes:
       - ./data/mysql:/var/lib/mysql
       - ./data/import:/docker-entrypoint-initdb.d

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -39,7 +39,7 @@ services:
     expose:
       - 3306
     restart: unless-stopped
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    command: --mysql-native-password=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     volumes:
       - ./data/mysql:/var/lib/mysql
       - ./data/import:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Beginning with MySQL 8.4.0, the deprecated mysql_native_password authentication plugin is no longer enabled by default. To enable it, start the server with [--mysql-native-password=ON](https://dev.mysql.com/doc/refman/8.4/en/server-options.html#option_mysqld_mysql-native-password) (added in MySQL 8.4.0), or by including mysql_native_password=ON in the [mysqld] section of your MySQL configuration file (added in MySQL 8.4.0).

https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html