### PR TITLE
fix(doc): add COOKIE_DOMAIN documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@
 # DB #
 ######
 
+# These values should match those in docker-compose.yml
 DB_HOST=db
 DB_PORT=3306
 DB_USERNAME=std_notes_user
@@ -13,14 +14,21 @@ DB_TYPE=mysql
 # CACHE #
 #########
 
+# These values should match those in docker-compose.yml
 REDIS_PORT=6379
 REDIS_HOST=cache
 CACHE_TYPE=redis
 
 ########
-# KEYS #
+# AUTH #
 ########
 
+# Generate with: openssl rand -hex 32
 AUTH_JWT_SECRET=
 AUTH_SERVER_ENCRYPTION_SERVER_KEY=
 VALET_TOKEN_SECRET=
+
+# Set to the the domain you're hosting on. It's easiest to use your apex domain.
+# For example, if hosting the server on `notes-api.mywebsite.com`, and the web
+# client on `notes.mywebsite.com`, set COOKIE_DOMAIN to `mywebsite.com`.
+COOKIE_DOMAIN=

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -232,6 +232,11 @@ if [ -z "$AUTH_SERVER_U2F_REQUIRE_USER_VERIFICATION" ]; then
   export AUTH_SERVER_U2F_REQUIRE_USER_VERIFICATION=false
 fi
 
+# Cookies
+if [ -z "$COOKIE_DOMAIN" ]; then
+  export COOKIE_DOMAIN="standardnotes.com"
+fi
+
 printenv | grep AUTH_SERVER_ | sed 's/AUTH_SERVER_//g' > /opt/server/packages/auth/.env
 
 ##################


### PR DESCRIPTION
In releases after
`standardnotes/server:5c02435ee478b893747d3f9e41062aae12d7ff10`, self-hosting fails without this environment variable.

For more information, see https://github.com/standardnotes/forum/issues/3635

This should be further documented in https://standardnotes.com/help/self-hosting/docker

Closes #3513
Closes #3635