### PR TITLE
Check if API_GATEWAY_PORT is set before setting it in the docker-entrypoint file

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -30,7 +30,9 @@ export MODE="self-hosted"
 # PORTS #
 #########
 
-export API_GATEWAY_PORT=3000
+if [ -z "$API_GATEWAY_PORT" ]; then
+  export API_GATEWAY_PORT=3000
+fi
 
 if [ -z "$SYNCING_SERVER_PORT" ]; then
   export SYNCING_SERVER_PORT=3101


### PR DESCRIPTION
Check if API_GATEWAY_PORT is set before setting it. This allows self-hosted users to use a different port from 3000 for the server.