### PR TITLE
Skip conflict when content is identical

### DIFF
--- a/packages/syncing-server/src/Domain/Item/SaveRule/TimeDifferenceFilter.spec.ts
+++ b/packages/syncing-server/src/Domain/Item/SaveRule/TimeDifferenceFilter.spec.ts
@@ -221,6 +221,51 @@ describe('TimeDifferenceFilter', () => {
     })
   })
 
+  it('should pass items with different timestamp but identical content (microsecond precision)', async () => {
+    itemHash = ItemHash.create({
+      ...itemHash.props,
+      content: 'foobar',
+      enc_item_key: undefined,
+      updated_at_timestamp: existingItem.props.timestamps.updatedAt + 1,
+    }).getValue()
+
+    const result = await createFilter().check({
+      userUuid: '1-2-3',
+      apiVersion: ApiVersion.v20200115,
+      snjsVersion: '2.200.0',
+      itemHash,
+      existingItem,
+    })
+
+    expect(result).toEqual({
+      passed: true,
+    })
+  })
+
+  it('should still conflict items with different timestamp AND different content', async () => {
+    itemHash = ItemHash.create({
+      ...itemHash.props,
+      content: 'totally different stuff',
+      updated_at_timestamp: existingItem.props.timestamps.updatedAt + 1,
+    }).getValue()
+
+    const result = await createFilter().check({
+      userUuid: '1-2-3',
+      apiVersion: ApiVersion.v20200115,
+      snjsVersion: '2.200.0',
+      itemHash,
+      existingItem,
+    })
+
+    expect(result).toEqual({
+      passed: false,
+      conflict: {
+        serverItem: existingItem,
+        type: 'sync_conflict',
+      },
+    })
+  })
+
   it('should leave items having update at timestamp different by less than a millisecond', async () => {
     itemHash = ItemHash.create({
       ...itemHash.props,

--- a/packages/syncing-server/src/Domain/Item/SaveRule/TimeDifferenceFilter.ts
+++ b/packages/syncing-server/src/Domain/Item/SaveRule/TimeDifferenceFilter.ts
@@ -37,6 +37,10 @@ export class TimeDifferenceFilter implements ItemSaveRuleInterface {
     if (this.itemHashHasMicrosecondsPrecision(dto.itemHash)) {
       const passed = difference === 0
 
+      if (!passed && this.contentIsIdentical(dto)) {
+        return { passed: true }
+      }
+
       return {
         passed,
         conflict: passed
@@ -49,6 +53,10 @@ export class TimeDifferenceFilter implements ItemSaveRuleInterface {
     }
 
     const passed = Math.abs(difference) < this.getMinimalConflictIntervalMicroseconds(dto.apiVersion)
+
+    if (!passed && this.contentIsIdentical(dto)) {
+      return { passed: true }
+    }
 
     return {
       passed,
@@ -67,6 +75,18 @@ export class TimeDifferenceFilter implements ItemSaveRuleInterface {
 
   private itemHashHasMicrosecondsPrecision(itemHash: ItemHash) {
     return itemHash.props.updated_at_timestamp !== undefined
+  }
+
+  private contentIsIdentical(dto: ItemSaveValidationDTO): boolean {
+    if (!dto.existingItem) {
+      return false
+    }
+    const incomingContent = dto.itemHash.props.content ?? null
+    const existingContent = dto.existingItem.props.content
+    const incomingEncKey = dto.itemHash.props.enc_item_key ?? null
+    const existingEncKey = dto.existingItem.props.encItemKey
+
+    return incomingContent !== null && incomingContent === existingContent && incomingEncKey === existingEncKey
   }
 
   private getMinimalConflictIntervalMicroseconds(apiVersion?: string): number {


### PR DESCRIPTION
Hi folks,

I got bitten by [issue 4021](https://github.com/standardnotes/forum/issues/4021) and I was surprised that all notes were duplicated.
According to [the help](https://standardnotes.com/help/33/how-do-i-clear-duplicates) these conflicts would only happen "_if there are any differences between the two copies_" but it didn't seem to work like I would expect it.
Because timestamp updates also create a conflict even if the content is the same.

This PR extends the logic slightly so that identical content won't create a sync conflict.
Currently the conflict is created, even if just the updated at timestamp was updated :man_shrugging: 

Maybe it's _something_!?

Also see [PR 2996](https://github.com/standardnotes/app/pull/2996). Both fixes are independent but kinda complementary

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev